### PR TITLE
use named function expressions instead of arguments.callee

### DIFF
--- a/lib/checks.js
+++ b/lib/checks.js
@@ -2,12 +2,14 @@
  * Copyright (c) 2012 Mathieu Turcotte
  * Licensed under the MIT license.
  */
+'use strict';
 
 var util = require('util');
 
 var errors = module.exports = require('./errors');
 
 function failCheck(ExceptionConstructor, callee, messageFormat, formatArgs) {
+    /* jshint validthis: true */
     messageFormat = messageFormat || '';
     var message = util.format.apply(this, [messageFormat].concat(formatArgs));
     var error = new ExceptionConstructor(message);
@@ -23,37 +25,37 @@ function failStateCheck(callee, message, formatArgs) {
     failCheck(errors.IllegalStateError, callee, message, formatArgs);
 }
 
-module.exports.checkArgument = function(value, message) {
+module.exports.checkArgument = function checkArgument(value, message) {
     if (!value) {
-        failArgumentCheck(arguments.callee, message,
+        failArgumentCheck(checkArgument, message,
             Array.prototype.slice.call(arguments, 2));
     }
 };
 
-module.exports.checkState = function(value, message) {
+module.exports.checkState = function checkState(value, message) {
     if (!value) {
-        failStateCheck(arguments.callee, message,
+        failStateCheck(checkState, message,
             Array.prototype.slice.call(arguments, 2));
     }
 };
 
-module.exports.checkIsDef = function(value, message) {
+module.exports.checkIsDef = function checkIsDef(value, message) {
     if (value !== undefined) {
         return value;
     }
 
-    failArgumentCheck(arguments.callee, message ||
+    failArgumentCheck(checkIsDef, message ||
         'Expected value to be defined but was undefined.',
         Array.prototype.slice.call(arguments, 2));
 };
 
-module.exports.checkIsDefAndNotNull = function(value, message) {
+module.exports.checkIsDefAndNotNull = function checkIsDefAndNotNull(value, message) {
     // Note that undefined == null.
     if (value != null) {
         return value;
     }
 
-    failArgumentCheck(arguments.callee, message ||
+    failArgumentCheck(checkIsDefAndNotNull, message ||
         'Expected value to be defined and not null but got "' +
         typeOf(value) + '".', Array.prototype.slice.call(arguments, 2));
 };
@@ -80,7 +82,7 @@ function typeCheck(expect) {
             return value;
         }
 
-        failArgumentCheck(arguments.callee, message ||
+        failArgumentCheck(typeCheck, message ||
             'Expected "' + expect + '" but got "' + type + '".',
             Array.prototype.slice.call(arguments, 2));
     };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2012 Mathieu Turcotte
  * Licensed under the MIT license.
  */
+ 'use strict';
 
 var util = require('util');
 


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments/callee, arguments.callee has been deprecated and can't be optimized at runtime. Named function expressions should get around this problem.