### PR TITLE
Use inherits and format-util for smaller bundle size

### DIFF
--- a/lib/checks.js
+++ b/lib/checks.js
@@ -3,13 +3,13 @@
  * Licensed under the MIT license.
  */
 
-var util = require('util');
+var format = require('format-util');
 
 var errors = module.exports = require('./errors');
 
 function failCheck(ExceptionConstructor, callee, messageFormat, formatArgs) {
     messageFormat = messageFormat || '';
-    var message = util.format.apply(this, [messageFormat].concat(formatArgs));
+    var message = format.apply(this, [messageFormat].concat(formatArgs));
     var error = new ExceptionConstructor(message);
     Error.captureStackTrace(error, callee);
     throw error;

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-var util = require('util');
+var inherits = require('inherits');
 
 function IllegalArgumentError(message) {
     Error.call(this, message);
@@ -17,7 +17,7 @@ function IllegalStateError(message) {
     Error.call(this, message);
     this.message = message;
 }
-util.inherits(IllegalStateError, Error);
+inherits(IllegalStateError, Error);
 
 IllegalStateError.prototype.name = 'IllegalStateError';
 

--- a/package.json
+++ b/package.json
@@ -1,27 +1,37 @@
 {
-    "name": "precond",
-    "description": "Precondition checking utilities.",
-    "version": "0.2.3",
-    "author": "Mathieu Turcotte <turcotte.mat@gmail.com>",
-    "keywords": ["precondition", "assert", "invariant", "contract", "condition"],
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/MathieuTurcotte/node-precond.git"
-    },
-    "devDependencies": {
-        "nodeunit": "0.9",
-        "jshint": "2.5"
-    },
-    "scripts": {
-        "pretest": "node_modules/.bin/jshint lib/ examples/ index.js",
-        "test": "node_modules/.bin/nodeunit tests/"
-    },
-    "engines": {
-        "node": ">= 0.6"
-    },
-    "files": [
-        "index.js",
-        "lib"
-    ]
+  "name": "precond",
+  "description": "Precondition checking utilities.",
+  "version": "0.2.3",
+  "author": "Mathieu Turcotte <turcotte.mat@gmail.com>",
+  "keywords": [
+    "precondition",
+    "assert",
+    "invariant",
+    "contract",
+    "condition"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MathieuTurcotte/node-precond.git"
+  },
+  "devDependencies": {
+    "nodeunit": "0.9",
+    "jshint": "2.5"
+  },
+  "scripts": {
+    "pretest": "node_modules/.bin/jshint lib/ examples/ index.js",
+    "test": "node_modules/.bin/nodeunit tests/"
+  },
+  "engines": {
+    "node": ">= 0.6"
+  },
+  "files": [
+    "index.js",
+    "lib"
+  ],
+  "dependencies": {
+    "format-util": "^1.0.3",
+    "inherits": "^2.0.3"
+  }
 }


### PR DESCRIPTION
`require('util')` takes up quite a bit of space when used in the browser. These modules (`inherits` and `format-util`) use the standard `require('util')` in Node, but have smaller implementations when built for the browser.

* Size before: 10563 bytes
* Size after: 2889 bytes

So this PR saves **7.67kB** or **72.6%** of the total size.

I measured the size using `browserify . | uglifyjs -mc | wc -c`.